### PR TITLE
Relax campaign intake for freeform audience and format (phase 1)

### DIFF
--- a/src/lib/server/agents/prompts/campaign-planner.ts
+++ b/src/lib/server/agents/prompts/campaign-planner.ts
@@ -1,4 +1,3 @@
-import { audienceOptions, formatOptions } from '$lib/validation/campaign';
 import type { CampaignPlannerInput } from '../schemas/campaign-planner';
 
 export const campaignPlannerSystemPrompt = `You are an expert campaign planning assistant for Christoph Holz's Campaign Studio.
@@ -31,19 +30,13 @@ Rules:
 - If a field is confidently inferred, fill it in resolvedFields.
 - If a field cannot be inferred with confidence, include it in missingFields.
 - readyToCreate must only be true when no required fields are missing.
-- audience should strongly prefer one of the allowed values listed in context.
-- format should strongly prefer one of the allowed values listed in context.
+- audience should be a concise freeform description (for example: "CIOs at mid-size manufacturers").
+- format should be a concise freeform description (for example: "Executive roundtable").
 - Never return prose outside JSON.
 - Return JSON only.`;
 
 export const campaignPlannerUserPrompt = (input: CampaignPlannerInput) =>
 	`Plan the campaign from this ongoing conversation.
-
-Allowed audience values:
-${JSON.stringify(audienceOptions)}
-
-Allowed format values:
-${JSON.stringify(formatOptions)}
 
 Current planner input:
 ${JSON.stringify(input, null, 2)}`;

--- a/src/lib/validation/campaign.ts
+++ b/src/lib/validation/campaign.ts
@@ -1,27 +1,23 @@
 import { z } from 'zod';
 
-export const audienceOptions = ['IT Companies', 'Banks', 'Associations (Verbände)'] as const;
-export const formatOptions = [
-	'Morning Keynotes',
-	'Endnotes',
-	'Business Breakfasts',
-	'Panel Moderations',
-	'Dinner Speeches'
-] as const;
+const requiredFreeformField = (label: string) =>
+	z
+		.string()
+		.trim()
+		.min(2, `${label} must be at least 2 characters`)
+		.max(120, `${label} must be 120 characters or fewer`);
 
 export const campaignFormSchema = z.object({
-	name: z.string().trim().min(2),
-	audience: z.enum(audienceOptions),
-	format: z.enum(formatOptions),
-	topic: z.string().trim().min(2),
-	language: z.string().trim().min(2),
-	geography: z.string().trim().min(2),
-	notes: z.string().trim().optional()
+	name: requiredFreeformField('Campaign name'),
+	audience: requiredFreeformField('Audience'),
+	format: requiredFreeformField('Format'),
+	topic: requiredFreeformField('Topic'),
+	language: requiredFreeformField('Language'),
+	geography: requiredFreeformField('Geography'),
+	notes: z.string().trim().max(2000, 'Notes must be 2000 characters or fewer').optional()
 });
 
 export type CampaignFormValues = z.infer<typeof campaignFormSchema>;
-export type AudienceOption = (typeof audienceOptions)[number];
-export type FormatOption = (typeof formatOptions)[number];
 export type CampaignFormSubmission = {
 	name: string;
 	audience: string;

--- a/src/routes/(app)/campaign/new/+page.server.ts
+++ b/src/routes/(app)/campaign/new/+page.server.ts
@@ -1,11 +1,6 @@
 import { fail, redirect } from '@sveltejs/kit';
 import type { Actions } from './$types';
-import {
-	audienceOptions,
-	campaignFormSchema,
-	formatOptions,
-	type CampaignFormSubmission
-} from '$lib/validation/campaign';
+import { campaignFormSchema, type CampaignFormSubmission } from '$lib/validation/campaign';
 import { createCampaign } from '$lib/server/campaigns/client';
 import { runCampaignPlanner } from '$lib/server/agents/campaign-planner';
 import { runGoogleAdsGenerationForCampaign } from '$lib/server/agents/google-ads-pipeline';
@@ -124,64 +119,6 @@ const parsePlannerState = (rawValue: FormDataEntryValue | null): PlannerState =>
 	}
 };
 
-const normalizeOption = (value: string, options: readonly string[]): string => {
-	const lowerValue = value.trim().toLowerCase();
-	const exact = options.find((option) => option.toLowerCase() === lowerValue);
-	return exact ?? '';
-};
-
-const normalizeAudience = (value: string): string => {
-	const exact = normalizeOption(value, audienceOptions);
-	if (exact) {
-		return exact;
-	}
-
-	const lower = value.trim().toLowerCase();
-	if (lower.includes('bank') || lower.includes('financ')) {
-		return 'Banks';
-	}
-
-	if (lower.includes('association') || lower.includes('verband')) {
-		return 'Associations (Verbände)';
-	}
-
-	if (lower.includes('it') || lower.includes('tech') || lower.includes('software')) {
-		return 'IT Companies';
-	}
-
-	return '';
-};
-
-const normalizeFormat = (value: string): string => {
-	const exact = normalizeOption(value, formatOptions);
-	if (exact) {
-		return exact;
-	}
-
-	const lower = value.trim().toLowerCase();
-	if (lower.includes('morning') && lower.includes('keynote')) {
-		return 'Morning Keynotes';
-	}
-
-	if (lower.includes('endnote')) {
-		return 'Endnotes';
-	}
-
-	if (lower.includes('business') && lower.includes('breakfast')) {
-		return 'Business Breakfasts';
-	}
-
-	if (lower.includes('panel') && (lower.includes('moderation') || lower.includes('moderator'))) {
-		return 'Panel Moderations';
-	}
-
-	if (lower.includes('dinner') && lower.includes('speech')) {
-		return 'Dinner Speeches';
-	}
-
-	return '';
-};
-
 const mergeResolvedFields = (
 	previous: CampaignFormSubmission,
 	proposed: Partial<CampaignFormSubmission>
@@ -195,13 +132,10 @@ const mergeResolvedFields = (
 		return trimmed.length ? trimmed : fallback;
 	};
 
-	const nextAudience = normalizeAudience(proposed.audience ?? '') || previous.audience;
-	const nextFormat = normalizeFormat(proposed.format ?? '') || previous.format;
-
 	return {
 		name: normalizeText(proposed.name, previous.name),
-		audience: nextAudience,
-		format: nextFormat,
+		audience: normalizeText(proposed.audience, previous.audience),
+		format: normalizeText(proposed.format, previous.format),
 		topic: normalizeText(proposed.topic, previous.topic),
 		language: normalizeText(proposed.language, previous.language),
 		geography: normalizeText(proposed.geography, previous.geography),
@@ -216,11 +150,11 @@ const getMissingPlannerFields = (values: CampaignFormSubmission): PlannerRequire
 		missing.push('name');
 	}
 
-	if (!normalizeOption(values.audience, audienceOptions)) {
+	if (!values.audience.trim()) {
 		missing.push('audience');
 	}
 
-	if (!normalizeOption(values.format, formatOptions)) {
+	if (!values.format.trim()) {
 		missing.push('format');
 	}
 

--- a/src/routes/(app)/campaign/new/+page.svelte
+++ b/src/routes/(app)/campaign/new/+page.svelte
@@ -2,14 +2,9 @@
 	import type { ActionData } from './$types';
 	import { applyAction, enhance } from '$app/forms';
 	import { onDestroy } from 'svelte';
-	import {
-		audienceOptions,
-		formatOptions,
-		type CampaignFormSubmission
-	} from '$lib/validation/campaign';
+	import { type CampaignFormSubmission } from '$lib/validation/campaign';
 	import Button from '$lib/components/elements/Button.svelte';
 	import Input from '$lib/components/elements/Input.svelte';
-	import Select from '$lib/components/elements/Select.svelte';
 	import TextArea from '$lib/components/elements/TextArea.svelte';
 	import MarkdownText from '$lib/components/elements/MarkdownText.svelte';
 
@@ -513,7 +508,7 @@
 						</li>
 						<li class="flex items-start gap-3">
 							<span class="text-(--accent)">•</span>
-							Audience and format establish tone. Choose the precise match.
+							Audience and format establish tone. Keep them specific and commercially clear.
 						</li>
 						<li class="flex items-start gap-3">
 							<span class="text-(--accent)">•</span>
@@ -547,24 +542,26 @@
 					></Input>
 
 					<div class="grid gap-6 md:grid-cols-2">
-						<Select
+						<Input
 							id="audience"
 							name="audience"
-							label="Audience"
-							options={audienceOptions}
-							placeholder="Select an audience"
+							type="text"
 							value={getValues().audience}
 							error={getFieldError('audience')}
-						></Select>
-						<Select
+							placeholder="CIOs at industrial enterprises"
+							autocomplete="off"
+							label="Audience"
+						></Input>
+						<Input
 							id="format"
 							name="format"
-							label="Format"
-							options={formatOptions}
-							placeholder="Select format"
+							type="text"
 							value={getValues().format}
 							error={getFieldError('format')}
-						></Select>
+							placeholder="Executive breakfast briefing"
+							autocomplete="off"
+							label="Format"
+						></Input>
 					</div>
 
 					<Input


### PR DESCRIPTION
## Summary
- Remove fixed audience/format enums from campaign intake validation and accept bounded freeform text instead.
- Update planner server logic to stop normalizing audience/format into legacy buckets and treat non-empty freeform values as complete.
- Update campaign planner prompts and manual campaign form UI to collect freeform audience/format values directly.

## Validation
- pnpm run format
- pnpm run check
- pnpm run build