### PR TITLE
Add wildcard prompt fallback for freeform audience/format (phase 2)

### DIFF
--- a/src/lib/components/PromptFormFields.svelte
+++ b/src/lib/components/PromptFormFields.svelte
@@ -1,5 +1,5 @@
 <script>
-	import { audienceOptions, formatOptions, purposeOptions } from '$lib/constants/prompts';
+	import { promptWildcardValue, purposeOptions } from '$lib/constants/prompts';
 	import Input from '$lib/components/elements/Input.svelte';
 	import Select from '$lib/components/elements/Select.svelte';
 	import TextArea from '$lib/components/elements/TextArea.svelte';
@@ -8,6 +8,7 @@
 	const values = () => props.values ?? {};
 	const errors = () => props.errors ?? {};
 	const isActive = () => values().is_active === 'true';
+	const wildcardHint = `Use ${promptWildcardValue} for wildcard fallback.`;
 </script>
 
 <div class="grid gap-8">
@@ -30,26 +31,25 @@
 			value={values().purpose ?? ''}
 			error={errors().purpose}
 		/>
-		<Select
+		<Input
 			id="audience"
 			name="audience"
 			label="Audience"
-			options={audienceOptions}
-			placeholder="Select audience"
 			value={values().audience ?? ''}
 			error={errors().audience}
+			placeholder="Banks, AI founders, or *"
 		/>
-		<Select
+		<Input
 			id="format"
 			name="format"
 			label="Format"
-			options={formatOptions}
-			placeholder="Select format"
 			value={values().format ?? ''}
 			error={errors().format}
+			placeholder="Panel moderation, keynote, or *"
 		/>
 		<Input id="topic" name="topic" label="Topic (optional)" value={values().topic ?? ''} />
 	</div>
+	<p class="text-[0.65rem] tracking-[0.12em] text-[#6b7280] uppercase">{wildcardHint}</p>
 
 	<div class="grid gap-8">
 		<Input

--- a/src/lib/constants/prompts.ts
+++ b/src/lib/constants/prompts.ts
@@ -1,16 +1,4 @@
-export const audienceOptions = [
-	{ label: 'IT Companies', value: 'IT Companies' },
-	{ label: 'Banks', value: 'Banks' },
-	{ label: 'Associations', value: 'Associations' }
-];
-
-export const formatOptions = [
-	{ label: 'Morning Keynote', value: 'Morning Keynote' },
-	{ label: 'Endnote', value: 'Endnote' },
-	{ label: 'Business Breakfast', value: 'Business Breakfast' },
-	{ label: 'Panel Moderation', value: 'Panel Moderation' },
-	{ label: 'Dinner Speech', value: 'Dinner Speech' }
-];
+export const promptWildcardValue = '*';
 
 export const purposeOptions = [
 	{ label: 'Intermediate content planning', value: 'intermediate' },

--- a/src/lib/server/prompts/client.ts
+++ b/src/lib/server/prompts/client.ts
@@ -1,13 +1,18 @@
 import { db } from '$lib/server/db';
 import { prompts } from '$lib/server/db/schema';
 import { and, asc, eq } from 'drizzle-orm';
-import { audienceOptions, formatOptions, purposeOptions } from '$lib/constants/prompts';
+import { promptWildcardValue, purposeOptions } from '$lib/constants/prompts';
 
 export type PromptPurpose = 'intermediate' | 'final' | 'edit_plan' | 'apply_plan';
 
+export const PROMPT_WILDCARD = promptWildcardValue;
+
+export function normalizePromptDimension(value: string): string {
+	return value.trim().replace(/\s+/g, ' ');
+}
+
 export const promptOptions = {
-	audiences: audienceOptions,
-	formats: formatOptions,
+	wildcard: PROMPT_WILDCARD,
 	purposes: purposeOptions
 };
 
@@ -364,13 +369,15 @@ export async function getPromptById(id: number): Promise<PromptRecord | null> {
 
 export async function createPrompt(input: PromptInput): Promise<PromptRecord> {
 	const normalizedTopic = normalizeTopic(input.topic);
+	const normalizedAudience = normalizePromptDimension(input.audience);
+	const normalizedFormat = normalizePromptDimension(input.format);
 	const [created] = await db
 		.insert(prompts)
 		.values({
 			name: input.name,
 			purpose: input.purpose,
-			audience: input.audience,
-			format: input.format,
+			audience: normalizedAudience,
+			format: normalizedFormat,
 			topic: normalizedTopic,
 			model: input.model,
 			system_prompt: input.system_prompt,
@@ -389,13 +396,15 @@ export async function createPrompt(input: PromptInput): Promise<PromptRecord> {
 
 export async function updatePrompt(id: number, input: PromptInput): Promise<PromptRecord> {
 	const normalizedTopic = normalizeTopic(input.topic);
+	const normalizedAudience = normalizePromptDimension(input.audience);
+	const normalizedFormat = normalizePromptDimension(input.format);
 	const [updated] = await db
 		.update(prompts)
 		.set({
 			name: input.name,
 			purpose: input.purpose,
-			audience: input.audience,
-			format: input.format,
+			audience: normalizedAudience,
+			format: normalizedFormat,
 			topic: normalizedTopic,
 			model: input.model,
 			system_prompt: input.system_prompt,
@@ -427,21 +436,49 @@ export interface PromptLookupOptions {
 export async function findPromptTemplate(
 	options: PromptLookupOptions
 ): Promise<PromptRecord | null> {
+	const normalizedAudience = normalizePromptDimension(options.audience) || PROMPT_WILDCARD;
+	const normalizedFormat = normalizePromptDimension(options.format) || PROMPT_WILDCARD;
 	const topicValue = normalizeTopic(options.topic);
-	const filters = [
-		eq(prompts.purpose, options.purpose),
-		eq(prompts.audience, options.audience),
-		eq(prompts.format, options.format),
-		eq(prompts.is_active, true),
-		eq(prompts.topic, topicValue)
+
+	const fallbackCandidates: Array<{ audience: string; format: string; topic: string }> = [
+		{ audience: normalizedAudience, format: normalizedFormat, topic: topicValue },
+		{ audience: normalizedAudience, format: normalizedFormat, topic: '' },
+		{ audience: normalizedAudience, format: PROMPT_WILDCARD, topic: topicValue },
+		{ audience: normalizedAudience, format: PROMPT_WILDCARD, topic: '' },
+		{ audience: PROMPT_WILDCARD, format: normalizedFormat, topic: topicValue },
+		{ audience: PROMPT_WILDCARD, format: normalizedFormat, topic: '' },
+		{ audience: PROMPT_WILDCARD, format: PROMPT_WILDCARD, topic: topicValue },
+		{ audience: PROMPT_WILDCARD, format: PROMPT_WILDCARD, topic: '' }
 	];
 
-	const [record] = await db
-		.select()
-		.from(prompts)
-		.where(and(...filters))
-		.limit(1);
-	return (record as PromptRecord) ?? null;
+	const seen = new Set<string>();
+	for (const candidate of fallbackCandidates) {
+		const key = `${candidate.audience}::${candidate.format}::${candidate.topic}`;
+		if (seen.has(key)) {
+			continue;
+		}
+		seen.add(key);
+
+		const filters = [
+			eq(prompts.purpose, options.purpose),
+			eq(prompts.audience, candidate.audience),
+			eq(prompts.format, candidate.format),
+			eq(prompts.is_active, true),
+			eq(prompts.topic, candidate.topic)
+		];
+
+		const [record] = await db
+			.select()
+			.from(prompts)
+			.where(and(...filters))
+			.limit(1);
+
+		if (record) {
+			return record as PromptRecord;
+		}
+	}
+
+	return null;
 }
 
 export function renderPromptTemplate(template: string, values: Record<string, string>): string {

--- a/src/routes/(app)/admin/prompts/[id]/+page.server.ts
+++ b/src/routes/(app)/admin/prompts/[id]/+page.server.ts
@@ -36,7 +36,7 @@ export const actions: Actions = {
 		} catch (err) {
 			const message =
 				err instanceof Error && err.message.includes('duplicate key')
-					? 'A prompt already exists for that audience/format combination'
+					? 'A prompt already exists for that purpose/audience/format/topic combination'
 					: 'Unable to update prompt';
 			return fail(400, { values: formValues, formError: message });
 		}

--- a/src/routes/(app)/admin/prompts/new/+page.server.ts
+++ b/src/routes/(app)/admin/prompts/new/+page.server.ts
@@ -22,7 +22,7 @@ export const actions: Actions = {
 		} catch (error) {
 			const message =
 				error instanceof Error && error.message.includes('duplicate key')
-					? 'A prompt already exists for that audience/format combination'
+					? 'A prompt already exists for that purpose/audience/format/topic combination'
 					: 'Unable to save prompt';
 			return fail(400, { values: formValues, formError: message });
 		}


### PR DESCRIPTION
## Summary
- Replace prompt admin audience/format dropdowns with freeform inputs and add explicit wildcard guidance using `*`.
- Normalize audience/format values on prompt create/update to reduce near-duplicate variants caused by spacing.
- Add deterministic prompt template fallback resolution in this order: exact match, topicless exact match, audience wildcard, format wildcard, and global wildcard defaults.

## Validation
- pnpm run format
- pnpm run check
- pnpm run build