### PR TITLE
Update keynote field mappings

### DIFF
--- a/src/lib/server/agents/config/landing-page-assets-store.ts
+++ b/src/lib/server/agents/config/landing-page-assets-store.ts
@@ -57,7 +57,7 @@ type LogoRow = {
 type KeynoteRow = {
 	id: string;
 	title: string;
-	summary: string;
+	summary: string | null;
 	audience: string | null;
 	keynoteShort: string | null;
 	imageUrl: string;
@@ -125,14 +125,14 @@ async function loadActiveKeynotes(): Promise<KeynoteRow[]> {
 		.select({
 			id: keynotes.id,
 			title: keynotes.keynote_title,
-			summary: keynotes.keynote_summary,
+			summary: keynotes.keynote_short,
 			audience: keynotes.audience,
 			keynoteShort: keynotes.keynote_short,
 			imageUrl: keynotes.image_url,
 			imageAlt: keynotes.image_alt
 		})
 		.from(keynotes)
-		.where(eq(keynotes.is_active, true))
+		.where(eq(keynotes.status, 'active'))
 		.orderBy(asc(keynotes.keynote_title), asc(keynotes.id));
 
 	return rows;
@@ -394,9 +394,9 @@ function buildKeynoteCatalog(rows: KeynoteRow[]): KeynoteOption[] {
 	return rows.map((keynote) => ({
 		id: keynote.id,
 		title: keynote.title,
-		summary: keynote.summary,
+		summary: keynote.keynoteShort ?? keynote.summary ?? '',
 		audience: keynote.audience ?? '',
-		keynoteShort: keynote.keynoteShort ?? keynote.summary,
+		keynoteShort: keynote.keynoteShort ?? keynote.summary ?? '',
 		imageUrl: keynote.imageUrl,
 		imageAlt: keynote.imageAlt
 	}));

--- a/src/lib/server/db/schema.ts
+++ b/src/lib/server/db/schema.ts
@@ -28,6 +28,7 @@ export const booking_reschedule_actor = pgEnum('booking_reschedule_actor', [
 	'admin',
 	'system'
 ]);
+export const keynote_status = pgEnum('keynote_status', ['active', 'draft', 'review', 'archived']);
 
 export const campaigns = pgTable('campaigns', {
 	id: serial('id').primaryKey(),
@@ -680,7 +681,6 @@ export const keynotes = pgTable(
 	{
 		id: text('id').primaryKey(),
 		keynote_title: text('keynote_title').notNull(),
-		keynote_summary: text('keynote_summary').notNull(),
 		theme: text('theme'),
 		audience: text('audience'),
 		language: text('language'),
@@ -688,6 +688,7 @@ export const keynotes = pgTable(
 		moderation: text('moderation'),
 		keynote_long: text('keynote_long'),
 		keynote_short: text('keynote_short'),
+		status: keynote_status('status').notNull().default('draft'),
 		speaker: text('speaker'),
 		image_url: text('image_url').notNull(),
 		image_bucket: text('image_bucket'),

--- a/src/lib/server/keynotes/keynote.ts
+++ b/src/lib/server/keynotes/keynote.ts
@@ -118,7 +118,6 @@ export async function createKeynote(
 	await db.insert(keynotes).values({
 		id,
 		keynote_title: input.keynoteTitle,
-		keynote_summary: input.keynoteSummary,
 		theme: input.theme,
 		audience: input.audience,
 		language: input.language,
@@ -140,7 +139,8 @@ export async function updateKeynote(
 	id: string,
 	input: KeynoteFormInput,
 	imageFile: File | null,
-	supabase: SupabaseClient
+	supabase: SupabaseClient,
+	status?: 'active' | 'draft' | 'review' | 'archived'
 ): Promise<void> {
 	const existing = await getKeynoteById(id);
 	if (!existing) {
@@ -163,7 +163,6 @@ export async function updateKeynote(
 		.update(keynotes)
 		.set({
 			keynote_title: input.keynoteTitle,
-			keynote_summary: input.keynoteSummary,
 			theme: input.theme,
 			audience: input.audience,
 			language: input.language,
@@ -171,6 +170,7 @@ export async function updateKeynote(
 			moderation: input.moderation,
 			keynote_long: input.keynoteLong,
 			keynote_short: input.keynoteShort,
+			...(status ? { status } : {}),
 			speaker: input.speaker,
 			image_url: imageUrl,
 			image_bucket: imageBucket,
@@ -189,6 +189,16 @@ export async function toggleKeynoteActive(id: string, active: boolean): Promise<
 	await db
 		.update(keynotes)
 		.set({ is_active: active, updated_at: new Date() })
+		.where(eq(keynotes.id, id));
+}
+
+export async function updateKeynoteStatus(
+	id: string,
+	status: 'active' | 'draft' | 'review' | 'archived'
+): Promise<void> {
+	await db
+		.update(keynotes)
+		.set({ status, updated_at: new Date() })
 		.where(eq(keynotes.id, id));
 }
 

--- a/src/lib/validation/keynotes.ts
+++ b/src/lib/validation/keynotes.ts
@@ -2,7 +2,6 @@ import { z } from 'zod';
 
 export const keynoteFormSchema = z.object({
 	keynoteTitle: z.string().trim().min(1, 'Keynote title is required.'),
-	keynoteSummary: z.string().trim().min(24, 'Keynote summary should be descriptive.'),
 	imageAlt: z.string().trim().min(1, 'Image alt text is required.'),
 	theme: z.string().trim(),
 	audience: z.string().trim(),
@@ -10,7 +9,7 @@ export const keynoteFormSchema = z.object({
 	subtitle: z.string().trim(),
 	moderation: z.string().trim(),
 	keynoteLong: z.string().trim(),
-	keynoteShort: z.string().trim(),
+	keynoteShort: z.string().trim().min(24, 'Keynote summary should be descriptive.'),
 	speaker: z.string().trim()
 });
 

--- a/src/routes/(app)/admin/keynotes/+page.server.ts
+++ b/src/routes/(app)/admin/keynotes/+page.server.ts
@@ -1,6 +1,13 @@
 import type { Actions, PageServerLoad } from './$types';
-import { deleteKeynote, listKeynotes, toggleKeynoteActive } from '$lib/server/keynotes/keynote';
+import {
+	deleteKeynote,
+	listKeynotes,
+	updateKeynoteStatus
+} from '$lib/server/keynotes/keynote';
 import { fail } from '@sveltejs/kit';
+
+const keynoteStatuses = ['active', 'draft', 'review', 'archived'] as const;
+type KeynoteStatus = (typeof keynoteStatuses)[number];
 
 export const load: PageServerLoad = async () => {
 	const keynotes = await listKeynotes();
@@ -8,16 +15,20 @@ export const load: PageServerLoad = async () => {
 };
 
 export const actions: Actions = {
-	toggle: async ({ request }) => {
+	status: async ({ request }) => {
 		const formData = await request.formData();
 		const id = String(formData.get('id') ?? '').trim();
-		const active = String(formData.get('active') ?? 'false') === 'true';
+		const status = String(formData.get('status') ?? '').trim() as KeynoteStatus;
 
 		if (!id) {
 			return fail(400, { success: false, message: 'Keynote ID is required.' });
 		}
 
-		await toggleKeynoteActive(id, active);
+		if (!keynoteStatuses.includes(status)) {
+			return fail(400, { success: false, message: 'Keynote status is invalid.' });
+		}
+
+		await updateKeynoteStatus(id, status);
 		return { success: true };
 	},
 	delete: async ({ request, locals }) => {

--- a/src/routes/(app)/admin/keynotes/+page.svelte
+++ b/src/routes/(app)/admin/keynotes/+page.svelte
@@ -2,6 +2,35 @@
 	import NavButton from '$lib/components/elements/NavButton.svelte';
 
 	let { data } = $props();
+
+	const keynoteStatuses = ['active', 'draft', 'review', 'archived'] as const;
+	type KeynoteStatus = (typeof keynoteStatuses)[number];
+
+	function statusLabel(status: KeynoteStatus): string {
+		switch (status) {
+			case 'active':
+				return 'Active';
+			case 'draft':
+				return 'Draft';
+			case 'review':
+				return 'Review';
+			case 'archived':
+				return 'Archived';
+		}
+	}
+
+	function statusClass(status: KeynoteStatus): string {
+		switch (status) {
+			case 'active':
+				return 'bg-emerald-100 text-emerald-800';
+			case 'draft':
+				return 'bg-neutral-200 text-neutral-700';
+			case 'review':
+				return 'bg-amber-100 text-amber-800';
+			case 'archived':
+				return 'bg-rose-100 text-rose-800';
+		}
+	}
 </script>
 
 <svelte:head>
@@ -32,7 +61,10 @@
 				{#each data.keynotes as keynote (keynote.id)}
 					<tr class="border-t border-neutral-100 align-top">
 						<td class="px-4 py-3">
-							<div class="flex items-center gap-3">
+							<a
+								href={`/admin/keynotes/${keynote.id}`}
+								class="flex items-center gap-3 font-sans no-underline"
+							>
 								<img
 									src={keynote.image_url}
 									alt={keynote.image_alt}
@@ -42,32 +74,33 @@
 									<div class="font-medium text-neutral-900">{keynote.keynote_title}</div>
 									<div class="text-xs text-neutral-500">{keynote.id}</div>
 								</div>
-							</div>
+							</a>
 						</td>
 						<td class="px-4 py-3">
 							<span
-								class={`rounded-full px-2 py-1 text-xs ${keynote.is_active ? 'bg-emerald-100 text-emerald-800' : 'bg-neutral-200 text-neutral-700'}`}
+								class={`rounded-full px-2 py-1 text-xs ${statusClass(keynote.status as KeynoteStatus)}`}
 							>
-								{keynote.is_active ? 'Active' : 'Inactive'}
+								{statusLabel(keynote.status as KeynoteStatus)}
 							</span>
 						</td>
 						<td class="px-4 py-3">
 							<div class="flex flex-wrap items-center gap-2">
-								<a
-									href={`/admin/keynotes/${keynote.id}`}
-									class="rounded border border-neutral-300 px-2 py-1 text-xs text-neutral-700 no-underline"
-								>
-									Edit
-								</a>
-								<form method="POST" action="?/toggle">
+								<form method="POST" action="?/status" class="flex items-center gap-2">
 									<input type="hidden" name="id" value={keynote.id} />
-									<input type="hidden" name="active" value={keynote.is_active ? 'false' : 'true'} />
-									<button
-										type="submit"
-										class="rounded border border-neutral-300 px-2 py-1 text-xs text-neutral-700"
-									>
-										{keynote.is_active ? 'Deactivate' : 'Activate'}
-									</button>
+									<label class="flex items-center gap-2 text-xs text-neutral-600">
+										<span>Status</span>
+										<select
+											name="status"
+											onchange={(event) => event.currentTarget.form?.requestSubmit()}
+											class="rounded border border-neutral-300 px-2 py-1 text-xs text-neutral-700"
+										>
+											{#each keynoteStatuses as status (status)}
+												<option value={status} selected={keynote.status === status}>
+													{statusLabel(status)}
+												</option>
+											{/each}
+										</select>
+									</label>
 								</form>
 								<form method="POST" action="?/delete">
 									<input type="hidden" name="id" value={keynote.id} />

--- a/src/routes/(app)/admin/keynotes/[id]/+page.server.ts
+++ b/src/routes/(app)/admin/keynotes/[id]/+page.server.ts
@@ -1,5 +1,8 @@
 import type { Actions, PageServerLoad } from './$types';
-import { getKeynoteById, updateKeynote } from '$lib/server/keynotes/keynote';
+import {
+	getKeynoteById,
+	updateKeynote
+} from '$lib/server/keynotes/keynote';
 import { keynoteFormSchema } from '$lib/validation/keynotes';
 import { error, fail, redirect } from '@sveltejs/kit';
 
@@ -16,7 +19,7 @@ export const load: PageServerLoad = async ({ params }) => {
 	return { keynote };
 };
 
-export const actions: Actions = {
+	export const actions: Actions = {
 	default: async ({ params, request, locals }) => {
 		const existing = await getKeynoteById(params.id);
 		if (!existing) {
@@ -25,9 +28,9 @@ export const actions: Actions = {
 
 		const formData = await request.formData();
 		const imageFile = formData.get('imageFile');
+		const status = String(formData.get('status') ?? '').trim();
 		const parsed = keynoteFormSchema.safeParse({
 			keynoteTitle: getString(formData, 'keynoteTitle'),
-			keynoteSummary: getString(formData, 'keynoteSummary'),
 			imageAlt: getString(formData, 'imageAlt'),
 			theme: getString(formData, 'theme'),
 			audience: getString(formData, 'audience'),
@@ -45,10 +48,20 @@ export const actions: Actions = {
 			});
 		}
 
+		if (!['active', 'draft', 'review', 'archived'].includes(status)) {
+			return fail(400, { formError: 'Keynote status is invalid.' });
+		}
+
 		const parsedImageFile = imageFile instanceof File ? imageFile : null;
 
 		try {
-			await updateKeynote(params.id, parsed.data, parsedImageFile, locals.supabase);
+			await updateKeynote(
+				params.id,
+				parsed.data,
+				parsedImageFile,
+				locals.supabase,
+				status as 'active' | 'draft' | 'review' | 'archived'
+			);
 		} catch (err) {
 			const message = err instanceof Error ? err.message : 'Unable to update keynote.';
 			return fail(400, { formError: message });

--- a/src/routes/(app)/admin/keynotes/[id]/+page.svelte
+++ b/src/routes/(app)/admin/keynotes/[id]/+page.svelte
@@ -4,6 +4,22 @@
 	import NavButton from '$lib/components/elements/NavButton.svelte';
 
 	let { data, form } = $props();
+
+	const keynoteStatuses = ['active', 'draft', 'review', 'archived'] as const;
+	type KeynoteStatus = (typeof keynoteStatuses)[number];
+
+	function statusLabel(status: KeynoteStatus): string {
+		switch (status) {
+			case 'active':
+				return 'Active';
+			case 'draft':
+				return 'Draft';
+			case 'review':
+				return 'Review';
+			case 'archived':
+				return 'Archived';
+		}
+	}
 </script>
 
 <svelte:head>
@@ -39,6 +55,20 @@
 				value={data.keynote.subtitle ?? ''}
 				class="rounded border border-neutral-300 px-3 py-2"
 			/>
+		</label>
+
+		<label class="flex flex-col gap-1 text-sm">
+			<span>Status</span>
+			<select
+				name="status"
+				class="rounded border border-neutral-300 px-3 py-2"
+			>
+				{#each keynoteStatuses as status (status)}
+					<option value={status} selected={data.keynote.status === status}>
+						{statusLabel(status)}
+					</option>
+				{/each}
+			</select>
 		</label>
 
 		<div class="grid gap-5 md:grid-cols-2">
@@ -96,16 +126,6 @@
 		</div>
 
 		<label class="flex flex-col gap-1 text-sm">
-			<span>Keynote summary</span>
-			<textarea
-				name="keynoteSummary"
-				required
-				rows="6"
-				class="rounded border border-neutral-300 px-3 py-2">{data.keynote.keynote_summary}</textarea
-			>
-		</label>
-
-		<label class="flex flex-col gap-1 text-sm">
 			<span>Moderation intro</span>
 			<textarea name="moderation" rows="6" class="rounded border border-neutral-300 px-3 py-2"
 				>{data.keynote.moderation ?? ''}</textarea
@@ -120,7 +140,7 @@
 		</label>
 
 		<label class="flex flex-col gap-1 text-sm">
-			<span>Short copy</span>
+			<span>Keynote summary</span>
 			<textarea name="keynoteShort" rows="6" class="rounded border border-neutral-300 px-3 py-2"
 				>{data.keynote.keynote_short ?? ''}</textarea
 			>

--- a/src/routes/(app)/admin/keynotes/new/+page.server.ts
+++ b/src/routes/(app)/admin/keynotes/new/+page.server.ts
@@ -15,7 +15,6 @@ export const actions: Actions = {
 		const imageFile = formData.get('imageFile');
 		const parsed = keynoteFormSchema.safeParse({
 			keynoteTitle: getString(formData, 'keynoteTitle'),
-			keynoteSummary: getString(formData, 'keynoteSummary'),
 			imageAlt: getString(formData, 'imageAlt'),
 			theme: getString(formData, 'theme'),
 			audience: getString(formData, 'audience'),

--- a/src/routes/(app)/admin/keynotes/new/+page.svelte
+++ b/src/routes/(app)/admin/keynotes/new/+page.svelte
@@ -68,16 +68,6 @@
 		</label>
 
 		<label class="flex flex-col gap-1 text-sm">
-			<span>Keynote summary</span>
-			<textarea
-				name="keynoteSummary"
-				required
-				rows="6"
-				class="rounded border border-neutral-300 px-3 py-2"
-			></textarea>
-		</label>
-
-		<label class="flex flex-col gap-1 text-sm">
 			<span>Moderation intro</span>
 			<textarea name="moderation" rows="6" class="rounded border border-neutral-300 px-3 py-2"
 			></textarea>
@@ -90,7 +80,7 @@
 		</label>
 
 		<label class="flex flex-col gap-1 text-sm">
-			<span>Short copy</span>
+			<span>Keynote summary</span>
 			<textarea name="keynoteShort" rows="6" class="rounded border border-neutral-300 px-3 py-2"
 			></textarea>
 		</label>

--- a/src/routes/(app)/campaigns/[id]/landing-page/+page.server.ts
+++ b/src/routes/(app)/campaigns/[id]/landing-page/+page.server.ts
@@ -633,14 +633,21 @@ export const actions: Actions = {
 			.select({
 				id: keynotes.id,
 				title: keynotes.keynote_title,
-				summary: keynotes.keynote_summary,
+				summary: keynotes.keynote_short,
 				imageUrl: keynotes.image_url
 			})
 			.from(keynotes)
-			.where(eq(keynotes.is_active, true))
+			.where(eq(keynotes.status, 'active'))
 			.orderBy(asc(keynotes.keynote_title), asc(keynotes.id));
 
-		const keynotesById = new Map(availableKeynotes.map((keynote) => [keynote.id, keynote]));
+		const availableKeynotesWithFallback = availableKeynotes.map((keynote) => ({
+			...keynote,
+			summary: keynote.summary ?? ''
+		}));
+
+		const keynotesById = new Map(
+			availableKeynotesWithFallback.map((keynote) => [keynote.id, keynote])
+		);
 		const resolvedKeynotes = selectedKeynoteIds
 			.map((id) => keynotesById.get(id))
 			.filter((keynote): keynote is NonNullable<typeof keynote> => Boolean(keynote))

--- a/src/routes/(app)/campaigns/[id]/landing-page/landing-page.remote.ts
+++ b/src/routes/(app)/campaigns/[id]/landing-page/landing-page.remote.ts
@@ -112,13 +112,18 @@ export const getLandingPagePreview = query(previewInputSchema, async ({ campaign
 		.select({
 			id: keynotes.id,
 			title: keynotes.keynote_title,
-			summary: keynotes.keynote_summary,
+			summary: keynotes.keynote_short,
 			imageUrl: keynotes.image_url,
 			imageAlt: keynotes.image_alt
 		})
 		.from(keynotes)
-		.where(eq(keynotes.is_active, true))
+		.where(eq(keynotes.status, 'active'))
 		.orderBy(asc(keynotes.keynote_title), asc(keynotes.id));
+
+	const availableKeynotesWithFallback = availableKeynotes.map((keynote) => ({
+		...keynote,
+		summary: keynote.summary ?? ''
+	}));
 
 	const availableHeroImages = await db
 		.select({
@@ -144,7 +149,7 @@ export const getLandingPagePreview = query(previewInputSchema, async ({ campaign
 		canRenderPage,
 		renderErrorMessage,
 		availableLogos,
-		availableKeynotes,
+		availableKeynotes: availableKeynotesWithFallback,
 		availableHeroImages: filteredHeroImages,
 		campaignId,
 		campaignPageId: selectedPageRecord?.campaignPageId ?? null,

--- a/supabase/migrations/036_drop_keynote_summary.sql
+++ b/supabase/migrations/036_drop_keynote_summary.sql
@@ -1,0 +1,10 @@
+begin;
+
+update public.keynotes
+set keynote_short = coalesce(nullif(trim(keynote_short), ''), keynote_summary)
+where keynote_summary is not null;
+
+alter table public.keynotes
+drop column if exists keynote_summary;
+
+commit;


### PR DESCRIPTION
## Summary
- switch keynote content mappings from `keynote_summary` to `keynote_short`
- remove `keynote_summary` with a follow-up migration after backfill
- filter landing-page keynote selection by `status = 'active'`
- add keynote status controls to the admin list and detail pages

## Verification
- pnpm run check
- pnpm run build