### PR TITLE
Add load more keynotes

### DIFF
--- a/src/lib/components/page-sections/HybridContentSection.svelte
+++ b/src/lib/components/page-sections/HybridContentSection.svelte
@@ -196,22 +196,10 @@
 				{#each benefits as benefit, index (`hybrid-benefit-${benefit.title}`)}
 					<article
 						data-reveal-index={index}
-						class={[
-							'relative flex h-full flex-col gap-4 transition-all duration-500 ease-out',
-							disableScrollReveal || visibleItems.has(index)
-								? 'translate-y-0 opacity-100'
-								: 'translate-y-8 opacity-0'
-						]}
-						style={`transition-delay: ${index * 120}ms`}
-						bind:this={itemRefs[index]}
+						class={['relative flex h-full flex-col gap-4 transition-all duration-500 ease-out']}
 					>
 						<span>0{index + 1}</span>
 
-						<!--<img
-							src={benefit.imageUrl ?? '/momentum.png'}
-							alt={benefit.title}
-							class="aspect-4/2 object-cover"
-						/>-->
 						<ContentEditableText
 							as="h3"
 							value={benefit.title}
@@ -263,14 +251,7 @@
 						{#each deepDiveItems as item, index (`hybrid-deep-dive-${item.title}`)}
 							<div
 								data-reveal-index={index + benefits.length}
-								class={[
-									'flex gap-4 transition-all duration-500 ease-out sm:gap-6',
-									disableScrollReveal || visibleItems.has(index + benefits.length)
-										? 'translate-y-0 opacity-100'
-										: 'translate-y-8 opacity-0'
-								]}
-								style={`transition-delay: ${index * 120}ms`}
-								bind:this={itemRefs[index + benefits.length]}
+								class={['flex gap-4 transition-all duration-500 ease-out sm:gap-6']}
 							>
 								<span class="text-lg text-primary">{`0${index + 1}`}</span>
 								<div>

--- a/src/lib/components/page-sections/HybridContentSection.svelte
+++ b/src/lib/components/page-sections/HybridContentSection.svelte
@@ -196,10 +196,22 @@
 				{#each benefits as benefit, index (`hybrid-benefit-${benefit.title}`)}
 					<article
 						data-reveal-index={index}
-						class={['relative flex h-full flex-col gap-4 transition-all duration-500 ease-out']}
+						class={[
+							'relative flex h-full flex-col gap-4 transition-all duration-500 ease-out',
+							disableScrollReveal || visibleItems.has(index)
+								? 'translate-y-0 opacity-100'
+								: 'translate-y-8 opacity-0'
+						]}
+						style={`transition-delay: ${index * 120}ms`}
+						bind:this={itemRefs[index]}
 					>
 						<span>0{index + 1}</span>
 
+						<!--<img
+							src={benefit.imageUrl ?? '/momentum.png'}
+							alt={benefit.title}
+							class="aspect-4/2 object-cover"
+						/>-->
 						<ContentEditableText
 							as="h3"
 							value={benefit.title}
@@ -248,10 +260,17 @@
 				/>
 				{#if deepDiveItems.length > 0}
 					<div class="space-y-10">
-						{#each deepDiveItems as item, index (`hybrid-deep-dive-${item.title}`)}
+					{#each deepDiveItems as item, index (`hybrid-deep-dive-${item.title}`)}
 							<div
 								data-reveal-index={index + benefits.length}
-								class={['flex gap-4 transition-all duration-500 ease-out sm:gap-6']}
+								class={[
+									'flex gap-4 transition-all duration-500 ease-out sm:gap-6',
+									disableScrollReveal || visibleItems.has(index + benefits.length)
+										? 'translate-y-0 opacity-100'
+										: 'translate-y-8 opacity-0'
+								]}
+								style={`transition-delay: ${index * 120}ms`}
+								bind:this={itemRefs[index + benefits.length]}
 							>
 								<span class="text-lg text-primary">{`0${index + 1}`}</span>
 								<div>

--- a/src/lib/components/page-sections/KeynoteSpeeches.remote.ts
+++ b/src/lib/components/page-sections/KeynoteSpeeches.remote.ts
@@ -1,0 +1,39 @@
+import { query } from '$app/server';
+import { db } from '$lib/server/db';
+import { keynotes } from '$lib/server/db/schema';
+import { asc, and, eq, notInArray } from 'drizzle-orm';
+import { z } from 'zod';
+
+const keynoteIdsSchema = z.object({
+	keynoteIds: z.array(z.string().trim().min(1)).min(3)
+});
+
+type KeynoteCard = {
+	id: string;
+	title: string;
+	imageUrl: string;
+	summary: string;
+};
+
+export const getAdditionalKeynotes = query(keynoteIdsSchema, async ({ keynoteIds }) => {
+	const uniqueKeynoteIds = [...new Set(keynoteIds)];
+
+	const rows = await db
+		.select({
+			id: keynotes.id,
+			title: keynotes.keynote_title,
+			imageUrl: keynotes.image_url,
+			summary: keynotes.keynote_short
+		})
+		.from(keynotes)
+		.where(and(eq(keynotes.status, 'active'), notInArray(keynotes.id, uniqueKeynoteIds)))
+		.orderBy(asc(keynotes.keynote_title), asc(keynotes.id))
+		.limit(3);
+
+	return rows.map(
+		(keynote): KeynoteCard => ({
+			...keynote,
+			summary: keynote.summary ?? ''
+		})
+	);
+});

--- a/src/lib/components/page-sections/KeynoteSpeeches.svelte
+++ b/src/lib/components/page-sections/KeynoteSpeeches.svelte
@@ -2,11 +2,14 @@
 	import { goto } from '$app/navigation';
 	import { page } from '$app/state';
 	import ContentEditableText from '$lib/components/inline-edit/ContentEditableText.svelte';
+	import Button from '../elements/Button.svelte';
 	import SectionIdentifier from '../elements/SectionIdentifier.svelte';
+	import { getAdditionalKeynotes } from './KeynoteSpeeches.remote';
 	import { saveKeynoteSpeechesField } from './KeynoteSpeechesInlineEdit.remote';
 	import { SvelteSet } from 'svelte/reactivity';
 
 	type Keynote = {
+		id: string;
 		title: string;
 		imageUrl: string;
 		summary: string;
@@ -15,6 +18,7 @@
 	type KeynoteSpeechesSectionProps = {
 		title: string;
 		intro: string;
+		keynoteIds: string[];
 		keynotes: Keynote[];
 	};
 
@@ -40,10 +44,18 @@
 	let innerHeight = $state(0);
 	let sectionEl = $state<HTMLElement | null>(null);
 	let visibleItems = new SvelteSet<number>();
+	let additionalKeynotes = $state<Keynote[]>([]);
+	let loadingMoreKeynotes = $state(false);
+	let hasMoreKeynotes = $state(true);
 	const revealOffset = 600;
 	const canInlineEdit = $derived(
 		editable && campaignId != null && campaignPageId != null && sectionIndex >= 0
 	);
+	const displayedKeynotes = $derived([...props.keynotes, ...additionalKeynotes]);
+	const displayedKeynoteIds = $derived([
+		...props.keynoteIds,
+		...additionalKeynotes.map((keynote) => keynote.id)
+	]);
 
 	async function saveKeynoteField(
 		field: 'title' | 'intro',
@@ -75,6 +87,22 @@
 			nextValue: result.value,
 			nextCampaignPageId: result.campaignPageId
 		};
+	}
+
+	async function loadMoreKeynotes(): Promise<void> {
+		if (loadingMoreKeynotes || !hasMoreKeynotes) {
+			return;
+		}
+
+		loadingMoreKeynotes = true;
+
+		try {
+			const nextKeynotes = await getAdditionalKeynotes({ keynoteIds: displayedKeynoteIds });
+			additionalKeynotes = [...additionalKeynotes, ...nextKeynotes];
+			hasMoreKeynotes = nextKeynotes.length === 3;
+		} finally {
+			loadingMoreKeynotes = false;
+		}
 	}
 
 	$effect(() => {
@@ -133,16 +161,10 @@
 
 		{#if props.keynotes.length > 0}
 			<div class="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
-				{#each props.keynotes as keynote, index (`keynote-${keynote.title}`)}
+				{#each displayedKeynotes as keynote, index (keynote.id)}
 					<article
 						data-reveal-index={index}
-						class={[
-							'relative flex h-full flex-col gap-4 transition-all duration-500 ease-out',
-							disableScrollReveal || visibleItems.has(index)
-								? 'translate-y-0 opacity-100'
-								: 'translate-y-8 opacity-0'
-						]}
-						style={`transition-delay: ${index * 120}ms`}
+						class={['relative flex h-full flex-col gap-4 transition-all duration-500 ease-out']}
 					>
 						<span>0{index + 1}</span>
 
@@ -158,6 +180,13 @@
 					</article>
 				{/each}
 			</div>
+			{#if hasMoreKeynotes}
+				<div class="mt-8 flex justify-center">
+					<Button variant="dark" isSubmitting={loadingMoreKeynotes} onclick={loadMoreKeynotes}>
+						{loadingMoreKeynotes ? 'Weitere Vorträge werden geladen…' : 'Weitere Vorträge anzeigen'}
+					</Button>
+				</div>
+			{/if}
 		{/if}
 	</div>
 </section>

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -5,6 +5,9 @@ import { relative, sep } from 'node:path';
 const config = {
 	compilerOptions: {
 		// defaults to rune mode for the project, execept for `node_modules`. Can be removed in svelte 6.
+		experimental: {
+			async: true
+		},
 		runes: ({ filename }) => {
 			const relativePath = relative(import.meta.dirname, filename);
 			const pathSegments = relativePath.toLowerCase().split(sep);


### PR DESCRIPTION
## Summary\n- add remote-driven load-more keynotes to the keynote speeches section\n- enable async Svelte support for inline await rendering\n- include the hybrid content section updates on this branch\n\n## Verification\n- pnpm run format\n- pnpm run check\n- pnpm run build